### PR TITLE
Add Makefile and Ubuntu build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+CC = gcc
+CFLAGS = -Wall -Wextra -std=c99
+
+SRCS = main.c parser.c macro.c symbol_table.c instructions.c output.c utils.c
+OBJS = $(SRCS:.c=.o)
+
+assembler: $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o $@
+
+clean:
+	rm -f $(OBJS) assembler
+
+.PHONY: assembler clean

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# cAssembler
+
+To build the assembler on Ubuntu:
+
+```sh
+sudo apt-get update && sudo apt-get install build-essential
+make
+```
+
+This compiles all `.c` files into the `assembler` executable. Run `make clean` to remove object files and the binary.


### PR DESCRIPTION
## Summary
- Add Makefile to compile assembler from all project sources and provide clean target.
- Document Ubuntu build steps in new README.

## Testing
- `make assembler` *(fails: unknown type name `SymbolTable`)*
- `make clean`


------
https://chatgpt.com/codex/tasks/task_e_6890847c11cc832dbd960e26cd0bd6ef