### PR TITLE
Add string and register utility helpers

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdarg.h>
 
 // Removes whitespace from the beginning and end of the string
 void trim_string(char* str) {
@@ -89,5 +90,79 @@ bool is_valid_label(const char* str) {
 void error_exit(const char* msg) {
     fprintf(stderr, "Error: %s\n", msg);
     exit(EXIT_FAILURE);
+}
+
+// Returns newly allocated filename without its extension
+char* strip_extension(const char* filename) {
+    const char *dot = strrchr(filename, '.');
+    size_t len = dot ? (size_t)(dot - filename) : strlen(filename);
+    char *res = malloc(len + 1);
+    if (!res) return NULL;
+    strncpy(res, filename, len);
+    res[len] = '\0';
+    return res;
+}
+
+// Returns newly allocated formatted string (like sprintf)
+char* strcat_printf(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    int len = vsnprintf(NULL, 0, fmt, ap);
+    va_end(ap);
+    char *res = malloc(len + 1);
+    if (!res) return NULL;
+    va_start(ap, fmt);
+    vsnprintf(res, len + 1, fmt, ap);
+    va_end(ap);
+    return res;
+}
+
+// Converts value into base-4 string with leading zeros (8 digits)
+void convert_to_base4(uint16_t value, char* out) {
+    for (int i = 7; i >= 0; --i) {
+        out[i] = '0' + (value & 0x3);
+        value >>= 2;
+    }
+    out[8] = '\0';
+}
+
+// Replace all occurrences of pattern with replacement in-place
+void replace_substring(char* str, const char* pattern, const char* replacement) {
+    size_t pat_len = strlen(pattern);
+    size_t repl_len = strlen(replacement);
+    const char *p = str;
+    int count = 0;
+    while ((p = strstr(p, pattern)) != NULL) {
+        count++;
+        p += pat_len;
+    }
+    size_t orig_len = strlen(str);
+    size_t new_len = orig_len + (repl_len > pat_len ? (repl_len - pat_len) * count : 0) + 1;
+    char *result = malloc(new_len);
+    if (!result) return;
+    char *outp = result;
+    const char *cur = str;
+    while ((p = strstr(cur, pattern)) != NULL) {
+        size_t len = p - cur;
+        memcpy(outp, cur, len);
+        outp += len;
+        memcpy(outp, replacement, repl_len);
+        outp += repl_len;
+        cur = p + pat_len;
+    }
+    strcpy(outp, cur);
+    strcpy(str, result);
+    free(result);
+}
+
+// Register helpers
+bool is_register(const char* str) {
+    return (str && (str[0] == 'r' || str[0] == 'R') &&
+            str[1] >= '0' && str[1] <= '7' && str[2] == '\0');
+}
+
+int reg_number(const char* str) {
+    if (!is_register(str)) return -1;
+    return str[1] - '0';
 }
 

--- a/utils.h
+++ b/utils.h
@@ -3,6 +3,7 @@
 #define UTILS_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 // Removes whitespace from the beginning and end of the string (in place)
 void trim_string(char* str);
@@ -25,5 +26,21 @@ bool is_valid_label(const char* str);
 
 // Prints an error message and exits the program
 void error_exit(const char* msg);
+
+// Returns newly allocated filename without its extension
+char* strip_extension(const char* filename);
+
+// Returns newly allocated formatted string (like sprintf)
+char* strcat_printf(const char* fmt, ...);
+
+// Converts value into base-4 string with leading zeros (8 digits)
+void convert_to_base4(uint16_t value, char* out);
+
+// Replace all occurrences of pattern with replacement in-place
+void replace_substring(char* str, const char* pattern, const char* replacement);
+
+// Register helpers
+bool is_register(const char* str);
+int  reg_number(const char* str);
 
 #endif // UTILS_H


### PR DESCRIPTION
## Summary
- Add declarations and implementations for several utility helpers including filename/format functions and register helpers.
- Support base-4 conversion and substring replacement used across macro, output, and instruction modules.

## Testing
- `make` *(fails: unknown type name 'SymbolTable')*


------
https://chatgpt.com/codex/tasks/task_e_6890897f6d60832dbbb18763987de4b4