### PR TITLE
Add centralized error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -std=c99
 
-SRCS = main.c parser.c macro.c symbol_table.c instructions.c output.c utils.c
+SRCS = main.c parser.c macro.c symbol_table.c instructions.c output.c utils.c error.c
 OBJS = $(SRCS:.c=.o)
 
 assembler: $(OBJS)

--- a/error.c
+++ b/error.c
@@ -1,0 +1,21 @@
+#include "error.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+static int error_count = 0;
+
+void print_error(const char *fmt, ...)
+{
+    va_list args;
+    fprintf(stderr, "Error: ");
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fputc('\n', stderr);
+    error_count++;
+}
+
+int get_error_count(void)
+{
+    return error_count;
+}

--- a/error.h
+++ b/error.h
@@ -1,0 +1,12 @@
+#ifndef ERROR_H
+#define ERROR_H
+
+#include <stdarg.h>
+
+/* Prints an error message and counts it */
+void print_error(const char *fmt, ...);
+
+/* Returns the number of errors recorded */
+int get_error_count(void);
+
+#endif /* ERROR_H */

--- a/main.c
+++ b/main.c
@@ -1,12 +1,15 @@
 // main.c
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <errno.h>
 #include "utils.h"
 #include "macro.h"
 #include "parser.h"
 #include "symbol_table.h"
 #include "instructions.h"
 #include "output.h"
+#include "error.h"
 
 static ParsedLine *all_lines = NULL;
 static int         line_count = 0;
@@ -14,7 +17,7 @@ static int         line_count = 0;
 /* Read whole file into a lines[] array */
 static bool read_input(const char *fname, char ***out_lines, int *out_n) {
     FILE *f = fopen(fname,"r");
-    if (!f) { perror("open"); return false; }
+    if (!f) { print_error("open %s: %s", fname, strerror(errno)); return false; }
     char **lines = malloc(sizeof(char*) * 2048);
     int n = 0;
     char buf[256];
@@ -59,7 +62,7 @@ static bool second_pass(SymbolTable *st, CPUState *cpu) {
 
 int main(int argc, char **argv) {
     if (argc != 2) {
-        fprintf(stderr,"Usage: %s <source.as>\n",argv[0]);
+        print_error("Usage: %s <source.as>", argv[0]);
         return 1;
     }
 
@@ -82,7 +85,7 @@ int main(int argc, char **argv) {
 
     int IC, DC;
     if (!first_pass(tmp, &st, &IC, &DC)) {
-        fprintf(stderr,"First pass failed\n");
+        print_error("First pass failed");
         return 1;
     }
 
@@ -100,7 +103,7 @@ int main(int argc, char **argv) {
 
     /* 4. Second pass: execute instructions */
     if (!second_pass(&st, &cpu)) {
-        fprintf(stderr,"Second pass failed\n");
+        print_error("Second pass failed");
         return 1;
     }
 

--- a/output.c
+++ b/output.c
@@ -1,7 +1,10 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <errno.h>
 #include "output.h"
 #include "utils.h"  // ל-format של שורות, convert_to_base4 וכד'
+#include "error.h"
 
 bool write_object_file(const char *filename,
                        const uint16_t *memory,
@@ -9,7 +12,7 @@ bool write_object_file(const char *filename,
                        int data_count)
 {
     FILE *f = fopen(filename, "w");
-    if (!f) { perror("open .ob"); return false; }
+    if (!f) { print_error("open %s: %s", filename, strerror(errno)); return false; }
 
     // שורה ראשונה: מספר הוראות ומספר מילים בקובץ נתונים
     fprintf(f, "%d %d\n", instruction_count, data_count);
@@ -28,7 +31,7 @@ bool write_entries_file(const char *filename,
                         const SymbolTable *symtab)
 {
     FILE *f = fopen(filename, "w");
-    if (!f) { perror("open .ent"); return false; }
+    if (!f) { print_error("open %s: %s", filename, strerror(errno)); return false; }
     // לכל סימבול שסומן .entry
     for (int i = 0; i < symtab->count; i++) {
         const Symbol *s = &symtab->symbols[i];
@@ -44,7 +47,7 @@ bool write_externals_file(const char *filename,
                           const SymbolTable *symtab)
 {
     FILE *f = fopen(filename, "w");
-    if (!f) { perror("open .ext"); return false; }
+    if (!f) { print_error("open %s: %s", filename, strerror(errno)); return false; }
     // בטבלת הזיקוצים החיצוניים (נשמרה במהלך second pass)
     for (int i = 0; i < symtab->ext_count; i++) {
         const ExtRef *er = &symtab->externals[i];

--- a/utils.c
+++ b/utils.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include "error.h"
 
 // Removes whitespace from the beginning and end of the string
 void trim_string(char* str) {
@@ -87,7 +88,7 @@ bool is_valid_label(const char* str) {
 
 // Prints an error message and exits the program
 void error_exit(const char* msg) {
-    fprintf(stderr, "Error: %s\n", msg);
+    print_error("%s", msg);
     exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
## Summary
- Introduce an `error` module providing `print_error` and `get_error_count`.
- Compile `error.c` as part of the build.
- Replace scattered `perror`/`fprintf` calls with `print_error`.

## Testing
- `make` *(fails: unknown type name 'SymbolTable')*


------
https://chatgpt.com/codex/tasks/task_e_6890898217e8832d89da1b5aa84fb222