### PR TITLE
Add centralized error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c99
+CFLAGS = -Wall -Wextra -std=c99 -Isrc
 
-SRCS = main.c parser.c macro.c symbol_table.c instructions.c output.c utils.c
+SRCS = main.c parser.c macro.c symbol_table.c instructions.c output.c utils.c src/error.c
 OBJS = $(SRCS:.c=.o)
 
 assembler: $(OBJS)

--- a/main.c
+++ b/main.c
@@ -7,6 +7,7 @@
 #include "symbol_table.h"
 #include "instructions.h"
 #include "output.h"
+#include "error.h"
 
 static ParsedLine *all_lines = NULL;
 static int         line_count = 0;
@@ -59,7 +60,7 @@ static bool second_pass(CPUState *cpu) {
 
 int main(int argc, char **argv) {
     if (argc != 2) {
-        fprintf(stderr,"Usage: %s <source.as>\n",argv[0]);
+        print_error("Usage: %s <source.as>", argv[0]);
         return 1;
     }
 
@@ -82,7 +83,7 @@ int main(int argc, char **argv) {
 
     int IC, DC;
     if (!first_pass(tmp, &st, &IC, &DC)) {
-        fprintf(stderr,"First pass failed\n");
+        print_error("First pass failed");
         return 1;
     }
 
@@ -101,7 +102,7 @@ int main(int argc, char **argv) {
 
     /* 4. Second pass: execute instructions */
     if (!second_pass(&cpu)) {
-        fprintf(stderr,"Second pass failed\n");
+        print_error("Second pass failed");
         return 1;
     }
 

--- a/parser.h
+++ b/parser.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#include "utils.h"          /* trim_string, is_valid_label, print_error */
+#include "utils.h"          /* trim_string, is_valid_label */
 #include "symbol_table.h"   /* add_label, add_label_external, relocate_data_symbols */
 #include "error.h"          /* get_error_count */
 

--- a/src/error.c
+++ b/src/error.c
@@ -1,0 +1,23 @@
+#include "error.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+static int error_count = 0;
+
+void increment_error_count(void) {
+    error_count++;
+}
+
+int get_error_count(void) {
+    return error_count;
+}
+
+void print_error(const char *fmt, ...) {
+    va_list args;
+    fprintf(stderr, "Error: ");
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fputc('\n', stderr);
+    increment_error_count();
+}

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,8 @@
+#ifndef ERROR_H
+#define ERROR_H
+
+void print_error(const char *fmt, ...);
+void increment_error_count(void);
+int get_error_count(void);
+
+#endif /* ERROR_H */


### PR DESCRIPTION
## Summary
- add `src/error.c` and `src/error.h` implementing `print_error`, `increment_error_count`, and `get_error_count`
- use `print_error` in `main.c` for top-level failures
- build `error.c` by default with `-Isrc`

## Testing
- `make` *(fails: undefined references to `init_symbol_table`, `strip_extension`, `strcat_printf`, `add_label`, `add_label_external`, `relocate_data_symbols`, `replace_substring`, `is_register`, and `reg_number`)*


------
https://chatgpt.com/codex/tasks/task_e_68908d56a1d0832daadb56d26eae7eb4