### PR TITLE
Implement symbol label helpers and relocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -std=c99 -Isrc
 
-SRCS = main.c parser.c macro.c symbol_table.c instructions.c output.c utils.c src/error.c
+SRCS = main.c parser.c macro.c symbol_table.c symbols.c instructions.c output.c utils.c src/error.c
 OBJS = $(SRCS:.c=.o)
 
 assembler: $(OBJS)

--- a/symbol_table.h
+++ b/symbol_table.h
@@ -21,7 +21,26 @@ typedef struct Symbol {
     struct Symbol* next;
 } Symbol;
 
-typedef Symbol SymbolTable; /* alias for clarity */
+/*
+ * The symbol table is represented as a simple singly linked list.
+ * We use a dummy head node (of type SymbolTable) whose 'next' pointer
+ * points to the first real symbol.  This allows functions that modify
+ * the list to receive a pointer to the head without needing a pointer
+ * to a pointer in most call sites.
+ */
+typedef Symbol SymbolTable; /* alias for clarity (dummy head node) */
+
+/* initialise an empty symbol table (sets the head's fields to defaults) */
+void init_symbol_table(SymbolTable *table);
+
+/* Add a label (code or data) to the table.  Returns false on duplicate. */
+bool add_label(SymbolTable *table, const char *name, int address, bool is_data);
+
+/* Add an external label to the table.  Returns false on duplicate. */
+bool add_label_external(SymbolTable *table, const char *name);
+
+/* Relocate all data symbols by adding 'offset' to their addresses. */
+void relocate_data_symbols(SymbolTable *table, int offset);
 
 // Adds a new symbol to the table. Returns pointer to new symbol (or NULL if duplicate).
 Symbol* add_symbol(Symbol** table, const char* name, int address, SymbolType type);

--- a/symbols.c
+++ b/symbols.c
@@ -1,0 +1,66 @@
+#include "symbol_table.h"
+#include "utils.h"
+#include "error.h"
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+/* initialise an empty symbol table */
+void init_symbol_table(SymbolTable *table) {
+    if (!table) return;
+    table->name[0] = '\0';
+    table->address = 0;
+    table->type = SYM_CODE; /* default, not really used for head */
+    table->next = NULL;
+}
+
+/*
+ * Add a new label (code or data) to the symbol table.
+ * Returns true on success, false if label already exists.
+ */
+bool add_label(SymbolTable *table, const char *name, int address, bool is_data) {
+    if (!table || !name) return false;
+    SymbolType type = is_data ? SYM_DATA : SYM_CODE;
+    /* add_symbol checks for duplicates; we use the list after the dummy head */
+    Symbol *sym = add_symbol(&table->next, name, address, type);
+    if (!sym) {
+        print_error("Duplicate symbol: %s", name);
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Add an external label.  Externals have address 0 and type SYM_EXTERNAL.
+ */
+bool add_label_external(SymbolTable *table, const char *name) {
+    if (!table || !name) return false;
+    char buf[32];
+    strncpy(buf, name, sizeof(buf));
+    buf[sizeof(buf)-1] = '\0';
+    trim_string(buf);
+    if (!is_valid_label(buf)) {
+        print_error("Invalid label name");
+        return false;
+    }
+    Symbol *sym = add_symbol(&table->next, buf, 0, SYM_EXTERNAL);
+    if (!sym) {
+        print_error("Duplicate symbol: %s", buf);
+        return false;
+    }
+    return true;
+}
+
+/*
+ * Relocate all data symbols by adding 'offset' to their address.
+ */
+void relocate_data_symbols(SymbolTable *table, int offset) {
+    if (!table) return;
+    Symbol *curr = table->next;
+    while (curr) {
+        if (curr->type == SYM_DATA)
+            curr->address += offset;
+        curr = curr->next;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add symbol table helpers for adding labels, externals and relocating data
- wire in initialisation and duplicate checks for new symbols
- update build to compile new symbol utilities

## Testing
- `make clean && make` *(fails: undefined reference to `strip_extension`, `strcat_printf`, `replace_substring`, `is_register`, `reg_number`)*
- `gcc -Wall -Wextra -std=c99 -Isrc -c symbols.c`

------
https://chatgpt.com/codex/tasks/task_e_68908f322868832db1e4fa4ff2191155