### PR TITLE
Add register utilities for encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -std=c99 -Isrc
 
-SRCS = main.c parser.c macro.c symbol_table.c symbols.c instructions.c output.c utils.c src/error.c
+SRCS = main.c parser.c macro.c symbol_table.c symbols.c instructions.c output.c utils.c registers.c src/error.c
 OBJS = $(SRCS:.c=.o)
 
 assembler: $(OBJS)

--- a/instructions.h
+++ b/instructions.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include "parser.h"       /* ParsedLine */
 #include "symbol_table.h" /* lookup_symbol */
-#include "utils.h"        /* is_register, reg_number */
+#include "registers.h"    /* is_register, reg_number */
 #include "error.h"        /* print_error */
 
 /* CPU state (registers, flags, memory pointer, program counter) */

--- a/registers.c
+++ b/registers.c
@@ -1,0 +1,19 @@
+#include <ctype.h>
+#include <string.h>
+
+#include "registers.h"
+
+bool is_register(const char *token) {
+    if (!token) return false;
+    /* Accept names like r0..r7 (case-insensitive) */
+    if (strlen(token) != 2) return false;
+    if (token[0] != 'r' && token[0] != 'R') return false;
+    if (token[1] < '0' || token[1] > '7') return false;
+    return true;
+}
+
+int reg_number(const char *token) {
+    if (!is_register(token)) return -1;
+    return token[1] - '0';
+}
+

--- a/registers.h
+++ b/registers.h
@@ -1,0 +1,12 @@
+#ifndef REGISTERS_H
+#define REGISTERS_H
+
+#include <stdbool.h>
+
+/* Check if the given token is a register name (R0-R7) */
+bool is_register(const char *token);
+
+/* Map register token to its numeric code (0-7). Returns -1 if invalid. */
+int reg_number(const char *token);
+
+#endif /* REGISTERS_H */


### PR DESCRIPTION
## Summary
- Implement register detection and numbering in new `registers` module.
- Include register utilities in instruction handling and build process.

## Testing
- `make` *(fails: undefined references to strip_extension/strcat_printf, replace_substring)*

------
https://chatgpt.com/codex/tasks/task_e_689091842124832d89be5530baf49dd2