### PR TITLE
Implement string replacement and concatenation utilities

### DIFF
--- a/macro.c
+++ b/macro.c
@@ -108,16 +108,18 @@ char **expand_macros(const char *lines[], int in_count, int *out_count, MacroTab
             }
             /* for each body line, substitute %param% */
             for (int b=0; b<md->body_len; b++) {
-                char tmp[MAX_LINE_LEN];
-                strncpy(tmp, md->body[b], MAX_LINE_LEN-1);
-                tmp[MAX_LINE_LEN-1] = '\0';
+                char *tmp = strdup(md->body[b]);
+                if (!tmp) error_exit("Memory allocation failed");
                 for (int pi=0; pi<md->param_count; pi++) {
                     char pattern[64], repl[64];
                     snprintf(pattern, sizeof(pattern), "%%%s%%", md->params[pi]);
                     snprintf(repl, sizeof(repl), "%s", (pi<ac?args[pi]:""));
-                    replace_substring(tmp, pattern, repl);  /* from utils */
+                    char *repl_tmp = replace_substring(tmp, pattern, repl);
+                    free(tmp);
+                    if (!repl_tmp) error_exit("Memory allocation failed");
+                    tmp = repl_tmp;
                 }
-                out[oc++] = strdup(tmp);
+                out[oc++] = tmp;
             }
         }
     }

--- a/main.c
+++ b/main.c
@@ -108,9 +108,19 @@ int main(int argc, char **argv) {
 
     /* 5. Emit files */
     const char *base = strip_extension(argv[1]);
-    write_object_file(   strcat_printf("%s.ob", base), cpu.memory, IC, DC);
-    write_entries_file(  strcat_printf("%s.ent", base), &st);
-    write_externals_file(strcat_printf("%s.ext", base), &st);
+    char *fname;
+
+    fname = strcat_printf(base, ".ob");
+    write_object_file(fname, cpu.memory, IC, DC);
+    free(fname);
+
+    fname = strcat_printf(base, ".ent");
+    write_entries_file(fname, &st);
+    free(fname);
+
+    fname = strcat_printf(base, ".ext");
+    write_externals_file(fname, &st);
+    free(fname);
 
     /* Cleanup */
     free(cpu.memory);

--- a/utils.c
+++ b/utils.c
@@ -103,3 +103,69 @@ void error_exit(const char* msg) {
     exit(EXIT_FAILURE);
 }
 
+// Replace all occurrences of substring `old` in `src` with `new_sub`.
+// Returns a newly allocated string or NULL on allocation failure.
+char *replace_substring(const char *src, const char *old, const char *new_sub) {
+    if (!src || !old || !new_sub) return NULL;
+
+    size_t src_len = strlen(src);
+    size_t old_len = strlen(old);
+    size_t new_len = strlen(new_sub);
+
+    if (old_len == 0) {
+        char *dup = malloc(src_len + 1);
+        if (!dup) return NULL;
+        strcpy(dup, src);
+        return dup;
+    }
+
+    size_t count = 0;
+    const char *p = src;
+    while ((p = strstr(p, old)) != NULL) {
+        count++;
+        p += old_len;
+    }
+
+    size_t result_len = src_len + count * (new_len - old_len);
+    char *result = malloc(result_len + 1);
+    if (!result) return NULL;
+
+    const char *src_p = src;
+    char *dst_p = result;
+    while ((p = strstr(src_p, old)) != NULL) {
+        size_t chunk = (size_t)(p - src_p);
+        memcpy(dst_p, src_p, chunk);
+        dst_p += chunk;
+        memcpy(dst_p, new_sub, new_len);
+        dst_p += new_len;
+        src_p = p + old_len;
+    }
+    strcpy(dst_p, src_p);
+
+    return result;
+}
+
+// Concatenate `base` and `suffix` into newly allocated string.
+// Returns NULL on allocation failure.
+char *strcat_printf(const char *base, const char *suffix) {
+    if (!base) base = "";
+    if (!suffix) suffix = "";
+    size_t len = strlen(base) + strlen(suffix);
+    char *res = malloc(len + 1);
+    if (!res) return NULL;
+    strcpy(res, base);
+    strcat(res, suffix);
+    return res;
+}
+
+// Strip file extension from `filename` and return a static buffer.
+const char *strip_extension(const char *filename) {
+    static char buf[256];
+    if (!filename) return NULL;
+    strncpy(buf, filename, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+    char *dot = strrchr(buf, '.');
+    if (dot) *dot = '\0';
+    return buf;
+}
+

--- a/utils.h
+++ b/utils.h
@@ -30,4 +30,18 @@ void convert_to_base4(uint16_t value, char *out);
 // Prints an error message and exits the program
 void error_exit(const char* msg);
 
+// Replace all occurrences of substring `old` in `src` with `new`.
+// Returns a newly allocated string which the caller must free.
+// Returns NULL on allocation failure.
+char *replace_substring(const char *src, const char *old, const char *new_sub);
+
+// Concatenate `base` and `suffix` into a newly allocated string.
+// Caller owns the returned string and must free it. Returns NULL on
+// allocation failure.
+char *strcat_printf(const char *base, const char *suffix);
+
+// Return a copy of `filename` without its extension. The returned pointer
+// refers to a static buffer that is overwritten on each call.
+const char *strip_extension(const char *filename);
+
 #endif // UTILS_H


### PR DESCRIPTION
## Summary
- add `replace_substring` and `strcat_printf` helper functions with documented memory ownership
- use `replace_substring` during macro expansion and manage intermediate buffers
- build output filenames with `strcat_printf` and free temporary strings

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689093083d8c832db5cf36ff04d9d4dd