### PR TITLE
Refactor assembler passes to use utility modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 CFLAGS = -Wall -Wextra -std=c99 -Isrc
 
-SRCS = main.c parser.c macro.c symbol_table.c symbols.c instructions.c output.c utils.c registers.c src/error.c
+SRCS = main.c parser.c first_pass.c second_pass.c macro.c symbol_table.c symbols.c instructions.c output.c utils.c registers.c src/error.c
 OBJS = $(SRCS:.c=.o)
 
 assembler: $(OBJS)

--- a/first_pass.c
+++ b/first_pass.c
@@ -1,0 +1,124 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "parser.h"
+#include "symbol_table.h"
+#include "utils.h"
+#include "registers.h"
+#include "error.h"
+
+/* Count comma-separated items using utils split_string */
+static int count_data_items(const char *args) {
+    char tokens[64][80];
+    return split_string(args, ',', tokens, 64);
+}
+
+/* Estimate number of machine words for an instruction */
+static int count_instruction_words(const ParsedLine *pl) {
+    int words = 1; /* base word */
+    if (pl->operands_raw[0] == '\0')
+        return words;
+
+    char ops[2][80];
+    int n = split_string(pl->operands_raw, ',', ops, 2);
+    bool reg_op[2] = {false, false};
+    for (int i = 0; i < n; i++)
+        reg_op[i] = is_register(ops[i]);
+
+    if (n == 1) {
+        words += reg_op[0] ? 0 : 1;
+    } else if (n == 2) {
+        if (reg_op[0] && reg_op[1]) {
+            words += 1; /* two registers share a word */
+        } else {
+            if (!reg_op[0]) words++;
+            if (!reg_op[1]) words++;
+        }
+    }
+    return words;
+}
+
+/* First pass: build symbol table, count IC/DC */
+bool first_pass(FILE *src, SymbolTable *symtab, int *IC_out, int *DC_out) {
+    char line[MAX_LINE_LEN];
+    int IC = 0, DC = 0, ln = 0;
+
+    while (fgets(line, sizeof(line), src)) {
+        ++ln;
+        ParsedLine pl;
+        if (!parse_line(line, &pl, ln))
+            continue; /* error already logged */
+
+        /* label addition */
+        if (pl.has_label && pl.type != STMT_LABEL_ONLY) {
+            bool is_data = (pl.type == STMT_DIRECTIVE &&
+                           (pl.dir_type == DIR_DATA ||
+                            pl.dir_type == DIR_STRING ||
+                            pl.dir_type == DIR_MAT));
+            add_label(symtab, pl.label, is_data ? DC : IC, is_data);
+        }
+
+        /* handle directives */
+        if (pl.type == STMT_DIRECTIVE) {
+            switch (pl.dir_type) {
+            case DIR_DATA: {
+                int n = count_data_items(pl.directive_args);
+                DC += n;
+                break;
+            }
+            case DIR_STRING: {
+                char *start = strchr(pl.directive_args, '"');
+                if (!start) {
+                    print_error("Missing opening quote");
+                    break;
+                }
+                char *end = strrchr(pl.directive_args, '"');
+                if (!end || end == start) {
+                    print_error("Missing closing quote");
+                    break;
+                }
+                DC += (int)(end - start - 1) + 1;
+                break;
+            }
+            case DIR_MAT: {
+                char toks[3][80];
+                int n = split_string(pl.directive_args, ',', toks, 3);
+                if (n < 2) {
+                    print_error("Invalid .mat directive");
+                    break;
+                }
+                int rows = atoi(toks[0]);
+                int cols = atoi(toks[1]);
+                DC += rows * cols;
+                break;
+            }
+            case DIR_EXTERN:
+                add_label_external(symtab, pl.directive_args);
+                break;
+            case DIR_ENTRY:
+                /* entry resolved in second pass */
+                break;
+            default:
+                print_error("Unsupported directive");
+            }
+            continue;
+        }
+
+        /* handle instructions */
+        if (pl.type == STMT_INSTRUCTION) {
+            IC += count_instruction_words(&pl);
+            continue;
+        }
+
+        /* label-only or empty/comment: do nothing */
+    }
+
+    /* relocate all data symbols by IC */
+    relocate_data_symbols(symtab, IC);
+
+    if (IC_out) *IC_out = IC;
+    if (DC_out) *DC_out = DC;
+    return (get_error_count() == 0);
+}
+

--- a/macro.c
+++ b/macro.c
@@ -1,6 +1,8 @@
+#define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 
 #include "macro.h"

--- a/main.c
+++ b/main.c
@@ -1,16 +1,16 @@
 // main.c
+#define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "utils.h"
 #include "macro.h"
 #include "parser.h"
 #include "symbol_table.h"
-#include "instructions.h"
 #include "output.h"
 #include "error.h"
+#include "second_pass.h"
 
-static ParsedLine *all_lines = NULL;
-static int         line_count = 0;
 
 /* Read whole file into a lines[] array */
 static bool read_input(const char *fname, char ***out_lines, int *out_n) {
@@ -28,35 +28,6 @@ static bool read_input(const char *fname, char ***out_lines, int *out_n) {
     return true;
 }
 
-/* Second pass: execute each instruction in order (fills cpu.memory) */
-static bool second_pass(CPUState *cpu) {
-    for (int i = 0; i < line_count; i++) {
-        ParsedLine *pl = &all_lines[i];
-        if (pl->type != STMT_INSTRUCTION) continue;
-        /* Dispatch based on opcode string */
-        if      (strcasecmp(pl->opcode,"MOV")==0) exec_mov(pl,cpu);
-        else if (strcasecmp(pl->opcode,"CMP")==0) exec_cmp(pl,cpu);
-        else if (strcasecmp(pl->opcode,"ADD")==0) exec_add(pl,cpu);
-        else if (strcasecmp(pl->opcode,"SUB")==0) exec_sub(pl,cpu);
-        else if (strcasecmp(pl->opcode,"LEA")==0) exec_lea(pl,cpu);
-        else if (strcasecmp(pl->opcode,"CLR")==0) exec_clr(pl,cpu);
-        else if (strcasecmp(pl->opcode,"NOT")==0) exec_not(pl,cpu);
-        else if (strcasecmp(pl->opcode,"INC")==0) exec_inc(pl,cpu);
-        else if (strcasecmp(pl->opcode,"DEC")==0) exec_dec(pl,cpu);
-        else if (strcasecmp(pl->opcode,"JMP")==0) exec_jmp(pl,cpu);
-        else if (strcasecmp(pl->opcode,"BNE")==0) exec_bne(pl,cpu);
-        else if (strcasecmp(pl->opcode,"JSR")==0) exec_jsr(pl,cpu);
-        else if (strcasecmp(pl->opcode,"RED")==0) exec_red(pl,cpu);
-        else if (strcasecmp(pl->opcode,"PRN")==0) exec_prn(pl,cpu);
-        else if (strcasecmp(pl->opcode,"STOP")==0) exec_stop(pl,cpu);
-        else {
-            print_error("Unrecognized opcode in second pass");
-            return false;
-        }
-        cpu->PC++;  /* advance to next memory cell */
-    }
-    return (get_error_count()==0);
-}
 
 int main(int argc, char **argv) {
     if (argc != 2) {
@@ -75,7 +46,6 @@ int main(int argc, char **argv) {
     /* 2. First pass */
     SymbolTable st; init_symbol_table(&st);
     ParsedLine *plarr = malloc(sizeof(*plarr)*flat_n);
-    all_lines = plarr;  line_count = flat_n;
 
     FILE *tmp = tmpfile();
     for(int i=0;i<flat_n;i++) fputs(flat[i],tmp);
@@ -101,7 +71,7 @@ int main(int argc, char **argv) {
     fclose(tmp);
 
     /* 4. Second pass: execute instructions */
-    if (!second_pass(&cpu)) {
+    if (!second_pass(plarr, flat_n, &cpu)) {
         print_error("Second pass failed");
         return 1;
     }

--- a/second_pass.c
+++ b/second_pass.c
@@ -1,0 +1,35 @@
+#include <strings.h>
+
+#include "second_pass.h"
+#include "error.h"
+
+/* Second pass: execute each instruction in order (fills cpu.memory) */
+bool second_pass(ParsedLine *lines, int line_count, CPUState *cpu) {
+    for (int i = 0; i < line_count; i++) {
+        ParsedLine *pl = &lines[i];
+        if (pl->type != STMT_INSTRUCTION) continue;
+        /* Dispatch based on opcode string */
+        if      (strcasecmp(pl->opcode,"MOV")==0) exec_mov(pl,cpu);
+        else if (strcasecmp(pl->opcode,"CMP")==0) exec_cmp(pl,cpu);
+        else if (strcasecmp(pl->opcode,"ADD")==0) exec_add(pl,cpu);
+        else if (strcasecmp(pl->opcode,"SUB")==0) exec_sub(pl,cpu);
+        else if (strcasecmp(pl->opcode,"LEA")==0) exec_lea(pl,cpu);
+        else if (strcasecmp(pl->opcode,"CLR")==0) exec_clr(pl,cpu);
+        else if (strcasecmp(pl->opcode,"NOT")==0) exec_not(pl,cpu);
+        else if (strcasecmp(pl->opcode,"INC")==0) exec_inc(pl,cpu);
+        else if (strcasecmp(pl->opcode,"DEC")==0) exec_dec(pl,cpu);
+        else if (strcasecmp(pl->opcode,"JMP")==0) exec_jmp(pl,cpu);
+        else if (strcasecmp(pl->opcode,"BNE")==0) exec_bne(pl,cpu);
+        else if (strcasecmp(pl->opcode,"JSR")==0) exec_jsr(pl,cpu);
+        else if (strcasecmp(pl->opcode,"RED")==0) exec_red(pl,cpu);
+        else if (strcasecmp(pl->opcode,"PRN")==0) exec_prn(pl,cpu);
+        else if (strcasecmp(pl->opcode,"STOP")==0) exec_stop(pl,cpu);
+        else {
+            print_error("Unrecognized opcode in second pass");
+            return false;
+        }
+        cpu->PC++;  /* advance to next memory cell */
+    }
+    return (get_error_count()==0);
+}
+

--- a/second_pass.h
+++ b/second_pass.h
@@ -1,0 +1,10 @@
+#ifndef SECOND_PASS_H
+#define SECOND_PASS_H
+
+#include <stdbool.h>
+#include "parser.h"
+#include "instructions.h"
+
+bool second_pass(ParsedLine *lines, int line_count, CPUState *cpu);
+
+#endif /* SECOND_PASS_H */


### PR DESCRIPTION
## Summary
- Factor first pass into its own module using new symbol, register and string utilities.
- Add dedicated second pass executor and hook it into main assembly flow.
- Update build system to compile new modules.

## Testing
- `make clean`
- `make assembler`


------
https://chatgpt.com/codex/tasks/task_e_68910d940c30832dab3b6e0d1759a154