### PR TITLE
Encode instructions into machine words

### DIFF
--- a/instructions.h
+++ b/instructions.h
@@ -10,36 +10,18 @@
 
 /* CPU state (registers, flags, memory pointer, program counter) */
 typedef struct {
-    uint16_t *memory;     /* pointer to assembled memory image */
+    uint16_t *memory;     /* pointer to assembled instruction words */
     uint16_t  PC;         /* program counter */
-    uint16_t  regs[8];    /* R0..R7 */
+    uint16_t  regs[8];    /* R0..R7 (unused for encoding but kept for compatibility) */
     bool      zero_flag;
     bool      sign_flag;
     SymbolTable *symtab;  /* symbol table for label resolution */
 } CPUState;
 
-/* Execute one instruction at pl->line_number */
-void exec_mov(const ParsedLine *pl, CPUState *cpu);
-void exec_cmp(const ParsedLine *pl, CPUState *cpu);
-void exec_add(const ParsedLine *pl, CPUState *cpu);
-void exec_sub(const ParsedLine *pl, CPUState *cpu);
-void exec_lea(const ParsedLine *pl, CPUState *cpu);
-void exec_clr(const ParsedLine *pl, CPUState *cpu);
-void exec_not(const ParsedLine *pl, CPUState *cpu);
-void exec_inc(const ParsedLine *pl, CPUState *cpu);
-void exec_dec(const ParsedLine *pl, CPUState *cpu);
-void exec_jmp(const ParsedLine *pl, CPUState *cpu);
-void exec_bne(const ParsedLine *pl, CPUState *cpu);
-void exec_jsr(const ParsedLine *pl, CPUState *cpu);
-void exec_red(const ParsedLine *pl, CPUState *cpu);
-void exec_prn(const ParsedLine *pl, CPUState *cpu);
-void exec_stop(const ParsedLine *pl, CPUState *cpu);
-
-/* Helper routines */
-int   resolve_operand(const char *operand, CPUState *cpu);
-void  set_operand(const char *operand, CPUState *cpu, uint16_t value);
-uint16_t get_operand(const char *operand, CPUState *cpu);
-void  update_flags(CPUState *cpu, uint16_t result);
+/* Encode an instruction into machine words.
+ * out_words must have capacity for at least 3 words.
+ * Returns the number of words encoded (>=1). */
+int encode_instruction(const ParsedLine *pl, CPUState *cpu, uint16_t out_words[3]);
 
 #endif /* INSTRUCTIONS_H */
 

--- a/main.c
+++ b/main.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
 
     /* 3. Allocate CPU & memory */
     CPUState cpu = {0};
-    cpu.memory = calloc(IC+DC, sizeof(uint16_t));
+    cpu.memory = calloc(IC, sizeof(uint16_t));
     cpu.PC     = 0;
     cpu.symtab = &st;
 
@@ -82,15 +82,12 @@ int main(int argc, char **argv) {
     const char *base = strip_extension(argv[1]);
     char *fname;
 
-    /* copy data segment after instructions */
     if (data_seg.count != DC) {
         print_error("Data count mismatch");
-    } else {
-        memcpy(cpu.memory + IC, data_seg.words, DC * sizeof(uint16_t));
     }
 
     fname = strcat_printf(base, ".ob");
-    write_object_file(fname, cpu.memory, IC, DC);
+    write_object_file(fname, cpu.memory, IC, data_seg.words, DC);
     free(fname);
 
     fname = strcat_printf(base, ".ent");

--- a/output.c
+++ b/output.c
@@ -4,8 +4,9 @@
 #include "utils.h"  // ל-format של שורות, convert_to_base4 וכד'
 
 bool write_object_file(const char *filename,
-                       const uint16_t *memory,
+                       const uint16_t *instructions,
                        int instruction_count,
+                       const uint16_t *data,
                        int data_count)
 {
     FILE *f = fopen(filename, "w");
@@ -14,10 +15,16 @@ bool write_object_file(const char *filename,
     // שורה ראשונה: מספר הוראות ומספר מילים בקובץ נתונים
     fprintf(f, "%d %d\n", instruction_count, data_count);
 
-    // הבא – נניח קידוד ה-machine words בבסיס 4
-    for (int i = 0; i < instruction_count + data_count; i++) {
+    // הוראות מקודדות
+    for (int i = 0; i < instruction_count; i++) {
         char buf[32];
-        convert_to_base4(memory[i], buf);       // מ-utils
+        convert_to_base4(instructions[i], buf);
+        fprintf(f, "%s\n", buf);
+    }
+    // ואחריהן קטע הנתונים
+    for (int i = 0; i < data_count; i++) {
+        char buf[32];
+        convert_to_base4(data[i], buf);
         fprintf(f, "%s\n", buf);
     }
     fclose(f);

--- a/output.h
+++ b/output.h
@@ -6,8 +6,9 @@
 
 /* Generates the object file (.ob) from memory image */
 bool write_object_file(const char *filename,
-                       const uint16_t *memory,
+                       const uint16_t *instructions,
                        int instruction_count,
+                       const uint16_t *data,
                        int data_count);
 
 /* Writes all labels שסומנו כ-entry ל-.ent */

--- a/second_pass.c
+++ b/second_pass.c
@@ -4,7 +4,7 @@
 #include "error.h"
 #include "symbol_table.h"
 
-/* Second pass: execute each instruction in order (fills cpu.memory) */
+/* Second pass: encode each instruction into cpu->memory */
 bool second_pass(ParsedLine *lines, int line_count, CPUState *cpu) {
     for (int i = 0; i < line_count; i++) {
         ParsedLine *pl = &lines[i];
@@ -18,28 +18,13 @@ bool second_pass(ParsedLine *lines, int line_count, CPUState *cpu) {
         }
 
         if (pl->type != STMT_INSTRUCTION) continue;
-        /* Dispatch based on opcode string */
-        if      (strcasecmp(pl->opcode,"MOV")==0) exec_mov(pl,cpu);
-        else if (strcasecmp(pl->opcode,"CMP")==0) exec_cmp(pl,cpu);
-        else if (strcasecmp(pl->opcode,"ADD")==0) exec_add(pl,cpu);
-        else if (strcasecmp(pl->opcode,"SUB")==0) exec_sub(pl,cpu);
-        else if (strcasecmp(pl->opcode,"LEA")==0) exec_lea(pl,cpu);
-        else if (strcasecmp(pl->opcode,"CLR")==0) exec_clr(pl,cpu);
-        else if (strcasecmp(pl->opcode,"NOT")==0) exec_not(pl,cpu);
-        else if (strcasecmp(pl->opcode,"INC")==0) exec_inc(pl,cpu);
-        else if (strcasecmp(pl->opcode,"DEC")==0) exec_dec(pl,cpu);
-        else if (strcasecmp(pl->opcode,"JMP")==0) exec_jmp(pl,cpu);
-        else if (strcasecmp(pl->opcode,"BNE")==0) exec_bne(pl,cpu);
-        else if (strcasecmp(pl->opcode,"JSR")==0) exec_jsr(pl,cpu);
-        else if (strcasecmp(pl->opcode,"RED")==0) exec_red(pl,cpu);
-        else if (strcasecmp(pl->opcode,"PRN")==0) exec_prn(pl,cpu);
-        else if (strcasecmp(pl->opcode,"STOP")==0) exec_stop(pl,cpu);
-        else {
-            print_error("Unrecognized opcode in second pass");
-            return false;
+
+        uint16_t words[3];
+        int count = encode_instruction(pl, cpu, words);
+        for (int w = 0; w < count; w++) {
+            cpu->memory[cpu->PC++] = words[w];
         }
-        cpu->PC++;  /* advance to next memory cell */
     }
-    return (get_error_count()==0);
+    return (get_error_count() == 0);
 }
 


### PR DESCRIPTION
## Summary
- Replace old exec functions with a new instruction encoder that generates opcode and addressing mode bits for each instruction.
- Second pass now writes encoded words into memory and advances PC by the instruction's word count.
- Update object file writer and main workflow to emit encoded instructions followed by the data segment.

## Testing
- `make assembler`


------
https://chatgpt.com/codex/tasks/task_e_68911ebdfdc4832da29c616e0f287623