### PR TITLE
Add RTS opcode and handle zero-operand instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,24 @@ make
 ```
 
 This compiles all `.c` files into the `assembler` executable. Run `make clean` to remove object files and the binary.
+
+## Opcode Table
+
+| Mnemonic | Opcode |
+|----------|--------|
+| MOV      | 0      |
+| CMP      | 1      |
+| ADD      | 2      |
+| SUB      | 3      |
+| LEA      | 4      |
+| CLR      | 5      |
+| NOT      | 6      |
+| INC      | 7      |
+| DEC      | 8      |
+| JMP      | 9      |
+| BNE      | 10     |
+| JSR      | 11     |
+| RED      | 12     |
+| PRN      | 13     |
+| RTS      | 14     |
+| STOP     | 15     |

--- a/first_pass.c
+++ b/first_pass.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "parser.h"
 #include "symbol_table.h"
@@ -12,6 +13,11 @@
 /* Estimate number of machine words for an instruction */
 static int count_instruction_words(const ParsedLine *pl) {
     int words = 1; /* base word */
+    /* Instructions without operands (RTS/STOP) occupy just one word */
+    if (strcasecmp(pl->opcode, "RTS") == 0 ||
+        strcasecmp(pl->opcode, "STOP") == 0)
+        return words;
+
     if (pl->operands_raw[0] == '\0')
         return words;
 

--- a/instructions.c
+++ b/instructions.c
@@ -4,7 +4,12 @@
 
 #include "instructions.h"
 
-/* Opcodes enumeration for encoding */
+/* Opcodes enumeration for encoding
+ * MOV=0  CMP=1  ADD=2  SUB=3  LEA=4
+ * CLR=5  NOT=6  INC=7  DEC=8
+ * JMP=9  BNE=10 JSR=11 RED=12 PRN=13
+ * RTS=14 STOP=15
+ */
 static int opcode_to_num(const char *opc) {
     if      (strcasecmp(opc, "MOV") == 0) return 0;
     else if (strcasecmp(opc, "CMP") == 0) return 1;
@@ -20,7 +25,8 @@ static int opcode_to_num(const char *opc) {
     else if (strcasecmp(opc, "JSR") == 0) return 11;
     else if (strcasecmp(opc, "RED") == 0) return 12;
     else if (strcasecmp(opc, "PRN") == 0) return 13;
-    else if (strcasecmp(opc, "STOP") == 0) return 14;
+    else if (strcasecmp(opc, "RTS")  == 0) return 14;
+    else if (strcasecmp(opc, "STOP") == 0) return 15;
     return -1;
 }
 
@@ -83,8 +89,8 @@ int encode_instruction(const ParsedLine *pl, CPUState *cpu, uint16_t out_words[3
     if (opc <= 4) { /* two-operand instructions */
         sscanf(pl->operands_raw, "%63[^,],%63s", src, dst);
         has_src = has_dst = true;
-    } else if (opc == 14) {
-        /* STOP has no operands */
+    } else if (opc == 14 || opc == 15) {
+        /* RTS and STOP have no operands */
     } else { /* single operand */
         sscanf(pl->operands_raw, "%63s", dst);
         has_dst = true;


### PR DESCRIPTION
## Summary
- Assign unique opcode IDs: RTS is 14 and STOP shifted to 15.
- Support RTS/STOP as no-operand instructions and ensure word counting handles them.
- Document opcode table including new identifiers.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6891beeab5a0832d916f225f8bb8568c