### PR TITLE
Add macro table cleanup

### DIFF
--- a/macro.c
+++ b/macro.c
@@ -17,10 +17,13 @@ void init_macro_table(MacroTable *mt) {
 /* Free any dynamically allocated memory inside the macro table */
 void free_macro_table(MacroTable *mt) {
     for (int i = 0; i < mt->count; i++) {
-        for (int j = 0; j < mt->macros[i].body_len; j++) {
-            free(mt->macros[i].body[j]);
+        MacroDef *md = &mt->macros[i];
+        for (int j = 0; j < md->body_len; j++) {
+            free(md->body[j]);
+            md->body[j] = NULL;
         }
-        mt->macros[i].body_len = 0;
+        md->body_len = 0;
+        md->param_count = 0;
     }
     mt->count = 0;
 }

--- a/macro.h
+++ b/macro.h
@@ -27,6 +27,7 @@ typedef struct {
 
 /* Public API: */
 void     init_macro_table(MacroTable *mt);
+/* Release memory used by macros and reset the table */
 void     free_macro_table(MacroTable *mt);
 bool     scan_macros(const char *lines[], int line_count, MacroTable *mt);
 /* Take input lines + macro table → produce output lines (caller frees) */

--- a/main.c
+++ b/main.c
@@ -101,6 +101,7 @@ cleanup:
     free_data_segment(&data_seg);
     free_external_uses(cpu.ext_uses);
     free_symbol_table(&st);
+    /* free all macro definitions */
     free_macro_table(&mt);
     if (flat) { for (int i = 0; i < flat_n; i++) free(flat[i]); free(flat); }
     if (raw) { for (int i = 0; i < raw_n; i++) free(raw[i]); free(raw); }


### PR DESCRIPTION
## Summary
- document macro table cleanup API
- free macro bodies and reset macro counts
- release macro definitions on assembler shutdown

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6891c52153b0832da3206a99709dccf1