### PR TITLE
Avoid generating empty entry/external files

### DIFF
--- a/main.c
+++ b/main.c
@@ -86,11 +86,13 @@ static bool assemble_file(const char *fname) {
     free(outname);
 
     outname = strcat_printf(base, ".ent");
-    write_entries_file(outname, &st);
+    if (!write_entries_file(outname, &st))
+        remove(outname);
     free(outname);
 
     outname = strcat_printf(base, ".ext");
-    write_externals_file(outname, cpu.ext_uses);
+    if (!write_externals_file(outname, cpu.ext_uses))
+        remove(outname);
     free(outname);
 
     ok = true;

--- a/output.h
+++ b/output.h
@@ -11,11 +11,17 @@ bool write_object_file(const char *filename,
                        const uint16_t *data,
                        int data_count);
 
-/* Writes all labels שסומנו כ-entry ל-.ent */
+/*
+ * Write all symbols marked as .entry to a .ent file. Returns true only if the
+ * file was created (i.e., at least one entry symbol exists).
+ */
 bool write_entries_file(const char *filename,
                         const Symbol *symtab);
 
-/* כותב את כל השימושים בסימבולים חיצוניים ל-.ext */
+/*
+ * Write all recorded uses of external symbols to a .ext file. Returns true
+ * only if the file was created (i.e., at least one external use exists).
+ */
 bool write_externals_file(const char *filename,
                           const ExternalUse *uses);
 


### PR DESCRIPTION
## Summary
- Skip creating .ent and .ext files when there are no entries or external usages
- Let main clean up stale files when no such output is generated

## Testing
- `make assembler`

------
https://chatgpt.com/codex/tasks/task_e_6891c62f5858832dbe0aa495bb68158f