### PR TITLE
Include addresses in object file

### DIFF
--- a/main.c
+++ b/main.c
@@ -82,7 +82,7 @@ static bool assemble_file(const char *fname) {
     }
 
     outname = strcat_printf(base, ".ob");
-    write_object_file(outname, cpu.memory, IC, data_seg.words, DC);
+    write_object_file(outname, cpu.memory, IC, data_seg.words, DC, 0);
     free(outname);
 
     outname = strcat_printf(base, ".ent");

--- a/output.c
+++ b/output.c
@@ -7,7 +7,8 @@ bool write_object_file(const char *filename,
                        const uint16_t *instructions,
                        int instruction_count,
                        const uint16_t *data,
-                       int data_count)
+                       int data_count,
+                       int base_address)
 {
     FILE *f = fopen(filename, "w");
     if (!f) { perror("open .ob"); return false; }
@@ -15,17 +16,20 @@ bool write_object_file(const char *filename,
     // שורה ראשונה: מספר הוראות ומספר מילים בקובץ נתונים
     fprintf(f, "%d %d\n", instruction_count, data_count);
 
-    // הוראות מקודדות
-    for (int i = 0; i < instruction_count; i++) {
-        char buf[32];
-        convert_to_base4(instructions[i], buf);
-        fprintf(f, "%s\n", buf);
+    // הוראות מקודדות עם כתובות
+    int address = base_address;
+    for (int i = 0; i < instruction_count; i++, address++) {
+        char addr_buf[32], word_buf[32];
+        convert_to_base4((uint16_t)address, addr_buf);
+        convert_to_base4(instructions[i], word_buf);
+        fprintf(f, "%s %s\n", addr_buf, word_buf);
     }
     // ואחריהן קטע הנתונים
-    for (int i = 0; i < data_count; i++) {
-        char buf[32];
-        convert_to_base4(data[i], buf);
-        fprintf(f, "%s\n", buf);
+    for (int i = 0; i < data_count; i++, address++) {
+        char addr_buf[32], word_buf[32];
+        convert_to_base4((uint16_t)address, addr_buf);
+        convert_to_base4(data[i], word_buf);
+        fprintf(f, "%s %s\n", addr_buf, word_buf);
     }
     fclose(f);
     return true;

--- a/output.h
+++ b/output.h
@@ -9,7 +9,8 @@ bool write_object_file(const char *filename,
                        const uint16_t *instructions,
                        int instruction_count,
                        const uint16_t *data,
-                       int data_count);
+                       int data_count,
+                       int base_address);
 
 /*
  * Write all symbols marked as .entry to a .ent file. Returns true only if the


### PR DESCRIPTION
## Summary
- Extend `write_object_file` to take a base address and output each instruction and data word with its address in base-4.
- Update object file generation call to supply a starting address.

## Testing
- `make assembler`

------
https://chatgpt.com/codex/tasks/task_e_6891c8deb318832da057ff22f71d5d35