### PR TITLE
Handle dynamic macro body capacity

### DIFF
--- a/macro.h
+++ b/macro.h
@@ -15,8 +15,9 @@ typedef struct {
     char        name[MAX_MACRO_NAME];
     int         param_count;
     char        params[MAX_MACRO_PARAMS][MAX_MACRO_NAME];
-    char       *body[MAX_LINES];
-    int         body_len;
+    char      **body;        /* dynamically sized array of body lines */
+    int         body_len;    /* number of used entries in body */
+    int         body_cap;    /* allocated capacity of body */
 } MacroDef;
 
 /* A table of all macros in this file */


### PR DESCRIPTION
## Summary
- Track macro body capacity and length, using dynamic arrays for macro definitions.
- Grow macro bodies as needed during scanning to avoid MAX_LINES overflow.
- Ensure `free_macro_table` cleans up dynamically allocated body storage.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68930a609a44832daed0b16709917ba1