### PR TITLE
Add base address constant for object output

### DIFF
--- a/first_pass.c
+++ b/first_pass.c
@@ -208,6 +208,9 @@ bool first_pass(FILE *src, SymbolTable *symtab, int *IC_out, int *DC_out, DataSe
     /* relocate all data symbols by IC */
     relocate_data_symbols(symtab, IC);
 
+    /* apply base address to all symbols */
+    relocate_all_symbols(symtab, BASE_ADDRESS);
+
     if (IC_out) *IC_out = IC;
     if (DC_out) *DC_out = DC;
     return (get_error_count() == 0);

--- a/instructions.c
+++ b/instructions.c
@@ -158,12 +158,14 @@ int encode_instruction(const ParsedLine *pl, CPUState *cpu, uint16_t out_words[3
         if (needs) {
             if (mode == AM_MATRIX) {
                 if (sym && sym->type == SYM_EXTERNAL)
-                    add_external_use(&cpu->ext_uses, sym->name, cpu->PC + count);
+                    add_external_use(&cpu->ext_uses, sym->name,
+                                     cpu->PC + count + BASE_ADDRESS);
                 out_words[count++] = sym ? sym->address : 0;
                 out_words[count++] = extra;
             } else {
                 if (sym && sym->type == SYM_EXTERNAL)
-                    add_external_use(&cpu->ext_uses, sym->name, cpu->PC + count);
+                    add_external_use(&cpu->ext_uses, sym->name,
+                                     cpu->PC + count + BASE_ADDRESS);
                 out_words[count++] = extra;
             }
         }
@@ -176,12 +178,14 @@ int encode_instruction(const ParsedLine *pl, CPUState *cpu, uint16_t out_words[3
         if (needs) {
             if (mode == AM_MATRIX) {
                 if (sym && sym->type == SYM_EXTERNAL)
-                    add_external_use(&cpu->ext_uses, sym->name, cpu->PC + count);
+                    add_external_use(&cpu->ext_uses, sym->name,
+                                     cpu->PC + count + BASE_ADDRESS);
                 out_words[count++] = sym ? sym->address : 0;
                 out_words[count++] = extra;
             } else {
                 if (sym && sym->type == SYM_EXTERNAL)
-                    add_external_use(&cpu->ext_uses, sym->name, cpu->PC + count);
+                    add_external_use(&cpu->ext_uses, sym->name,
+                                     cpu->PC + count + BASE_ADDRESS);
                 out_words[count++] = extra;
             }
         }

--- a/main.c
+++ b/main.c
@@ -112,7 +112,7 @@ static bool assemble_file(const char *fname) {
     }
 
     outname = strcat_printf(base, ".ob");
-    write_object_file(outname, cpu.memory, IC, data_seg.words, DC, 0);
+    write_object_file(outname, cpu.memory, IC, data_seg.words, DC, BASE_ADDRESS);
     free(outname);
 
     outname = strcat_printf(base, ".ent");

--- a/symbol_table.h
+++ b/symbol_table.h
@@ -5,6 +5,9 @@
 
 #include <stdbool.h>
 
+/* Base address for the assembled program in memory */
+#define BASE_ADDRESS 100
+
 // Symbol type: code, data, entry, external
 typedef enum {
     SYM_CODE,
@@ -48,6 +51,9 @@ bool add_label_external(SymbolTable *table, const char *name);
 
 /* Relocate all data symbols by adding 'offset' to their addresses. */
 void relocate_data_symbols(SymbolTable *table, int offset);
+
+/* Relocate all symbols (code and data) by adding 'offset' to their addresses. */
+void relocate_all_symbols(SymbolTable *table, int offset);
 
 // Adds a new symbol to the table. Returns pointer to new symbol (or NULL if duplicate).
 Symbol* add_symbol(Symbol** table, const char* name, int address, SymbolType type);

--- a/symbols.c
+++ b/symbols.c
@@ -64,3 +64,13 @@ void relocate_data_symbols(SymbolTable *table, int offset) {
     }
 }
 
+/* Relocate all symbols (code and data) by adding 'offset'. */
+void relocate_all_symbols(SymbolTable *table, int offset) {
+    if (!table) return;
+    Symbol *curr = table->next;
+    while (curr) {
+        curr->address += offset;
+        curr = curr->next;
+    }
+}
+


### PR DESCRIPTION
## Summary
- define `BASE_ADDRESS` for program memory origin and expose relocation helper
- relocate symbol table with base offset and adjust external reference tracking
- pass base address to object file writer for correct address emission

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_6893631e9388832dbb6fc2263347fb0c