### PR TITLE
Refactor parsing to use dynamic strings

### DIFF
--- a/first_pass.c
+++ b/first_pass.c
@@ -80,6 +80,8 @@ bool first_pass(FILE *src, SymbolTable *symtab, int *IC_out, int *DC_out, DataSe
         ++ln;
         ParsedLine pl;
         if (!parse_line(line, &pl, ln)) {
+            free(pl.directive_args);
+            free(pl.operands_raw);
             free(line);
             line = NULL;
             continue; /* error already logged */
@@ -185,6 +187,8 @@ bool first_pass(FILE *src, SymbolTable *symtab, int *IC_out, int *DC_out, DataSe
             default:
                 print_error("Unsupported directive");
             }
+            free(pl.directive_args);
+            free(pl.operands_raw);
             free(line);
             line = NULL;
             continue;
@@ -193,12 +197,16 @@ bool first_pass(FILE *src, SymbolTable *symtab, int *IC_out, int *DC_out, DataSe
         /* handle instructions */
         if (pl.type == STMT_INSTRUCTION) {
             IC += count_instruction_words(&pl);
+            free(pl.directive_args);
+            free(pl.operands_raw);
             free(line);
             line = NULL;
             continue;
         }
 
         /* label-only or empty/comment: do nothing */
+        free(pl.directive_args);
+        free(pl.operands_raw);
         free(line);
         line = NULL;
     }

--- a/macro.h
+++ b/macro.h
@@ -6,9 +6,7 @@
 
 #define MAX_MACRO_NAME   32
 #define MAX_MACRO_PARAMS  8
-#define MAX_LINE_LEN    256
 #define MAX_MACROS      64
-#define MAX_LINES      1024
 
 /* One macro definition */
 typedef struct {

--- a/main.c
+++ b/main.c
@@ -142,7 +142,13 @@ cleanup:
         free(flat);
     }
     if (raw) { for (int i = 0; i < raw_n; i++) free(raw[i]); free(raw); }
-    free(plarr);
+    if (plarr) {
+        for (int i = 0; i < flat_n; i++) {
+            free(plarr[i].directive_args);
+            free(plarr[i].operands_raw);
+        }
+        free(plarr);
+    }
     return ok;
 }
 

--- a/parser.h
+++ b/parser.h
@@ -9,7 +9,6 @@
 #include "error.h"          /* get_error_count */
 #include "data_segment.h"  /* DataSegment */
 
-#define MAX_LINE_LEN     256
 #define MAX_LABEL_LEN     32
 #define MAX_OPCODE_LEN    10
 
@@ -42,11 +41,11 @@ typedef struct {
 
     /* directive-specific */
     DirectiveType dir_type;
-    char          directive_args[MAX_LINE_LEN];
+    char         *directive_args;    /* dynamically allocated */
 
     /* instruction-specific */
     char          opcode[MAX_OPCODE_LEN];
-    char          operands_raw[MAX_LINE_LEN];
+    char         *operands_raw;      /* dynamically allocated */
 } ParsedLine;
 
 /* Public API */


### PR DESCRIPTION
## Summary
- Parse source lines using `strdup` instead of a fixed `MAX_LINE_LEN` buffer
- Handle macros and parsed lines with dynamically sized strings
- Remove obsolete `MAX_LINE_LEN`/`MAX_LINES` constants and free parsed resources

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6893890ca998832db62c1c38ae8b2ef5