### PR TITLE
Prevent reserved words as labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -std=c99 -Isrc
+CFLAGS = -Wall -Wextra -std=c99 -Isrc -I.
 
 SRCS = main.c parser.c first_pass.c second_pass.c macro.c symbol_table.c symbols.c instructions.c output.c utils.c registers.c data_segment.c src/error.c
 OBJS = $(SRCS:.c=.o)
@@ -7,7 +7,16 @@ OBJS = $(SRCS:.c=.o)
 assembler: $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@
 
-clean:
-	rm -f $(OBJS) assembler
+TEST_SRCS = tests/test_reserved_labels.c utils.c
+TEST_OBJS = $(TEST_SRCS:.c=.o)
 
-.PHONY: assembler clean
+test_reserved_labels: $(TEST_OBJS)
+	$(CC) $(CFLAGS) $(TEST_OBJS) -o $@
+
+test: test_reserved_labels
+	./test_reserved_labels
+
+clean:
+	rm -f $(OBJS) assembler $(TEST_OBJS) test_reserved_labels
+
+.PHONY: assembler clean test test_reserved_labels

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ make
 
 This compiles all `.c` files into the `assembler` executable. Run `make clean` to remove object files and the binary.
 
+## Labels and Reserved Words
+
+Label names must begin with a letter and may contain letters, digits, or the
+underscore character.  In addition, label names cannot use any reserved terms
+such as opcode mnemonics (e.g. `MOV`), assembler directives (e.g. `.data`), or
+register identifiers (`r0`-`r7`).
+
 ## Opcode Table
 
 | Mnemonic | Opcode |

--- a/parser.c
+++ b/parser.c
@@ -64,7 +64,10 @@ bool parse_line(const char *src, ParsedLine *out, int line_no) {
         strncpy(out->label, p, len);
         out->label[len] = '\0';
         if (!is_valid_label(out->label)) {
-            print_error("Invalid label name");
+            if (is_reserved_word(out->label))
+                print_error("Label cannot be a reserved word");
+            else
+                print_error("Invalid label name");
             free(buf);
             return false;
         }

--- a/parser.h
+++ b/parser.h
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-#include "utils.h"          /* trim_string, is_valid_label */
+#include "utils.h"          /* trim_string, is_valid_label, is_reserved_word */
 #include "symbol_table.h"   /* add_label, add_label_external, relocate_data_symbols */
 #include "error.h"          /* get_error_count */
 #include "data_segment.h"  /* DataSegment */

--- a/symbols.c
+++ b/symbols.c
@@ -40,7 +40,10 @@ bool add_label_external(SymbolTable *table, const char *name) {
     buf[sizeof(buf)-1] = '\0';
     trim_string(buf);
     if (!is_valid_label(buf)) {
-        print_error("Invalid label name");
+        if (is_reserved_word(buf))
+            print_error("Label cannot be a reserved word");
+        else
+            print_error("Invalid label name");
         return false;
     }
     Symbol *sym = add_symbol(&table->next, buf, 0, SYM_EXTERNAL);

--- a/tests/test_reserved_labels.c
+++ b/tests/test_reserved_labels.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include "utils.h"
+
+int main(void) {
+    assert(is_reserved_word("mov"));
+    assert(is_reserved_word("r7"));
+    assert(is_reserved_word("data"));
+    assert(!is_reserved_word("mylabel"));
+
+    assert(!is_valid_label("mov"));
+    assert(!is_valid_label("r7"));
+    assert(is_valid_label("my_label"));
+    return 0;
+}

--- a/utils.c
+++ b/utils.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include <stdint.h>
 
 // Removes whitespace from the beginning and end of the string
@@ -73,6 +74,42 @@ void to_upper_case(char* str) {
     }
 }
 
+// Returns true if the string matches an opcode mnemonic, directive, or register
+bool is_reserved_word(const char *s) {
+    if (!s) return false;
+
+    static const char *opcodes[] = {
+        "MOV", "CMP", "ADD", "SUB", "LEA",
+        "CLR", "NOT", "INC", "DEC", "JMP",
+        "BNE", "JSR", "RED", "PRN", "RTS", "STOP",
+        NULL
+    };
+
+    static const char *directives[] = {
+        "DATA", "STRING", "MAT", "ENTRY", "EXTERN",
+        NULL
+    };
+
+    static const char *registers[] = {
+        "R0", "R1", "R2", "R3", "R4", "R5", "R6", "R7",
+        NULL
+    };
+
+    for (int i = 0; opcodes[i]; ++i)
+        if (strcasecmp(s, opcodes[i]) == 0)
+            return true;
+
+    for (int i = 0; directives[i]; ++i)
+        if (strcasecmp(s, directives[i]) == 0)
+            return true;
+
+    for (int i = 0; registers[i]; ++i)
+        if (strcasecmp(s, registers[i]) == 0)
+            return true;
+
+    return false;
+}
+
 // Returns true if the given string is a valid label name
 bool is_valid_label(const char* str) {
     if (!str || !isalpha((unsigned char)str[0]))
@@ -83,6 +120,8 @@ bool is_valid_label(const char* str) {
             return false;
         i++;
     }
+    if (is_reserved_word(str))
+        return false;
     return true;
 }
 

--- a/utils.h
+++ b/utils.h
@@ -21,6 +21,9 @@ int split_string(const char* str, char delimiter, char tokens[][80], int max_tok
 // Converts a string to uppercase (in place)
 void to_upper_case(char* str);
 
+// Returns true if the string is an opcode, directive, or register name
+bool is_reserved_word(const char *s);
+
 // Returns true if the given string is a valid label name (starts with a letter, contains only alphanumeric or _)
 bool is_valid_label(const char* str);
 


### PR DESCRIPTION
## Summary
- disallow opcode mnemonics, directives, and register names from being used as labels
- report specific errors when labels match reserved words
- document label restrictions and add a unit test

## Testing
- `make clean && make test`


------
https://chatgpt.com/codex/tasks/task_e_6894596e8954832da7fc2e57486bd799