### PR TITLE
Handle invalid .entry on external symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,20 @@ assembler: $(OBJS)
 TEST_SRCS = tests/test_reserved_labels.c utils.c
 TEST_OBJS = $(TEST_SRCS:.c=.o)
 
+TEST_EXT_SRCS = tests/test_external_entry.c second_pass.c symbol_table.c src/error.c
+TEST_EXT_OBJS = $(TEST_EXT_SRCS:.c=.o)
+
 test_reserved_labels: $(TEST_OBJS)
 	$(CC) $(CFLAGS) $(TEST_OBJS) -o $@
 
-test: test_reserved_labels
+test_external_entry: $(TEST_EXT_OBJS)
+	$(CC) $(CFLAGS) $(TEST_EXT_OBJS) -o $@
+
+test: test_reserved_labels test_external_entry
 	./test_reserved_labels
+	./test_external_entry
 
 clean:
-	rm -f $(OBJS) assembler $(TEST_OBJS) test_reserved_labels
+	rm -f $(OBJS) assembler $(TEST_OBJS) $(TEST_EXT_OBJS) test_reserved_labels test_external_entry
 
-.PHONY: assembler clean test test_reserved_labels
+.PHONY: assembler clean test test_reserved_labels test_external_entry

--- a/second_pass.c
+++ b/second_pass.c
@@ -12,7 +12,7 @@ bool second_pass(ParsedLine *lines, int line_count, CPUState *cpu) {
         /* Handle .entry directives: mark symbol as entry */
         if (pl->type == STMT_DIRECTIVE && pl->dir_type == DIR_ENTRY) {
             if (!update_symbol_type(cpu->symtab, pl->directive_args, SYM_ENTRY)) {
-                print_error("Undefined entry label: %s", pl->directive_args);
+                print_error("Invalid .entry for label: %s", pl->directive_args);
             }
             continue; /* no machine code emitted */
         }

--- a/symbol_table.c
+++ b/symbol_table.c
@@ -1,5 +1,6 @@
 // symbol_table.c
 #include "symbol_table.h"
+#include "error.h"  /* print_error */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -40,6 +41,10 @@ Symbol* lookup_symbol(SymbolTable* table, const char* name) {
 bool update_symbol_type(Symbol* table, const char* name, SymbolType new_type) {
     Symbol* sym = find_symbol(table, name);
     if (!sym) return false;
+    if (sym->type == SYM_EXTERNAL && new_type == SYM_ENTRY) {
+        print_error("Cannot declare external symbol as entry: %s", name);
+        return false;
+    }
     sym->type = new_type;
     return true;
 }

--- a/tests/test_external_entry.c
+++ b/tests/test_external_entry.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <stdint.h>
+#include "second_pass.h"
+#include "symbol_table.h"
+#include "error.h"
+
+/* Stub for encode_instruction to satisfy linker */
+int encode_instruction(const ParsedLine *pl, CPUState *cpu, uint16_t out_words[3]) {
+    (void)pl; (void)cpu; (void)out_words;
+    return 0;
+}
+
+int main(void) {
+    Symbol *symtab = NULL;
+    add_symbol(&symtab, "EXTSYM", 0, SYM_EXTERNAL);
+
+    CPUState cpu = {0};
+    uint16_t memory[1] = {0};
+    cpu.memory = memory;
+    cpu.PC = 0;
+    cpu.symtab = symtab;
+    cpu.ext_uses = NULL;
+
+    ParsedLine line = {0};
+    line.type = STMT_DIRECTIVE;
+    line.dir_type = DIR_ENTRY;
+    line.directive_args = "EXTSYM";
+
+    ParsedLine lines[] = { line };
+
+    bool ok = second_pass(lines, 1, &cpu);
+    assert(!ok);
+    assert(get_error_count() == 2);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prevent external symbols from being marked as `.entry`
- surface invalid `.entry` directives during second pass
- add regression test covering external symbol erroneously declared `.entry`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6895034ea054832da3e744980ba606f3